### PR TITLE
Update links to "LINQ: Building an IQueryable Provider" tutorial

### DIFF
--- a/xml/System.Linq/IQueryable.xml
+++ b/xml/System.Linq/IQueryable.xml
@@ -44,7 +44,7 @@
   
  The <xref:System.Linq.IQueryable> interface inherits the <xref:System.Collections.IEnumerable> interface so that if it represents a query, the results of that query can be enumerated. Enumeration causes the expression tree associated with an <xref:System.Linq.IQueryable> object to be executed. The definition of "executing an expression tree" is specific to a query provider. For example, it may involve translating the expression tree to an appropriate query language for the underlying data source. Queries that do not return enumerable results are executed when the <xref:System.Linq.IQueryProvider.Execute%2A> method is called.  
   
- For more information about how to create your own LINQ provider, see [LINQ: Building an IQueryable Provider](https://go.microsoft.com/fwlink/?LinkID=112370) on MSDN Blogs.  
+ For more information about how to create your own LINQ provider, see [LINQ: Building an IQueryable Provider](https://github.com/mattwar/iqtoolkit/tree/master/docs/blog) on GitHub.
   
  ]]></format>
     </remarks>

--- a/xml/System.Linq/IQueryable`1.xml
+++ b/xml/System.Linq/IQueryable`1.xml
@@ -68,7 +68,7 @@
   
  The `static` (`Shared` in Visual Basic) methods defined in the class <xref:System.Linq.Queryable> (except for <xref:System.Linq.Queryable.AsQueryable%2A>, <xref:System.Linq.Queryable.ThenBy%2A>, and <xref:System.Linq.Queryable.ThenByDescending%2A>) extend objects of types that implement the <xref:System.Linq.IQueryable%601> interface.  
   
- For more information about how to create your own LINQ provider, see [LINQ: Building an IQueryable Provider](https://go.microsoft.com/fwlink/?LinkID=112370) on MSDN Blogs.  
+ For more information about how to create your own LINQ provider, see [LINQ: Building an IQueryable Provider](https://github.com/mattwar/iqtoolkit/tree/master/docs/blog) on GitHub.
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
Fix link in IQueryable<>, IQueryable

## Summary

Links to the "LINQ: Building an IQueryable Provider" tutorial lead to the old MSDN blog, it is archived, thus links are broken.
We could fix links by pointing to [new address](https://docs.microsoft.com/en-gb/archive/blogs/schlepticons/linq-building-an-iqueryable-provider-series), or we could fix it by pointing it to GiHub version (thanks to @mattwar for releasing it there).
The latter is more preferable because it has better formatting (e.g. code snippets have highlighting).

What do you think, could we merge links fixes?